### PR TITLE
Fix/sorted sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,19 @@ sets:
 - sInter (+ store)
 - sUnion (+ store)
 
+sorted sets:
+- zCount
+- zRank
+- zCard
+- zScore
+- zRandMember
+
+maybe:
+- zScan
+- zRangeByScore
+- zRangeByLex
+- zLexCount
+
 
 #### Extended Methods
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ Submit a PR if you like. But before you do, please do the following:
 - rPop
 - brPop
 - brPoplPush
+- zAdd
+- zIncrBy
+- zRange
+- zRem
+- zCard
+- zCount
+- zScore
+- zRank
+- zRevRank
 
 
 TODO: more
@@ -211,19 +220,6 @@ sets:
 - sDiff (+ store)
 - sInter (+ store)
 - sUnion (+ store)
-
-sorted sets:
-- zCount
-- zRank
-- zCard
-- zScore
-- zRandMember
-
-maybe:
-- zScan
-- zRangeByScore
-- zRangeByLex
-- zLexCount
 
 
 #### Extended Methods

--- a/src/CredisAdapter.php
+++ b/src/CredisAdapter.php
@@ -172,7 +172,7 @@ class CredisAdapter extends Rdb
     /** @inheritdoc */
     public function set(string $key, string $value, int $ttl = 0, array $flags = [])
     {
-        $flags = self::parseFlags($flags);
+        $flags = self::parseSetFlags($flags);
 
         $options = [];
 

--- a/src/CredisAdapter.php
+++ b/src/CredisAdapter.php
@@ -521,31 +521,46 @@ class CredisAdapter extends Rdb
     /** @inheritdoc */
     public function zAdd(string $key, ...$members): int
     {
-        $res = $this->credis->zadd($key, ...$members);
-        return $res;
+        $key = $this->config->prefix . $key;
+
+        $args = $members;
+        array_unshift($args, $key);
+
+        $res = $this->credis->__call('zadd', $members);
+        return (int) $res;
     }
 
 
     /** @inheritdoc */
-    public function zIncrby(string $key, ...$members): int
+    public function zIncrBy(string $key, float $value, string $member): float
     {
-        return $this->credis->zincrby($key, ...$members);
+        $key = $this->config->prefix . $key;
+        return (float) $this->credis->zIncrBy($key, $value, $member);
     }
 
 
     /** @inheritdoc */
     public function zRange(string $key, int $start, int $stop, bool $withscores = false): ?array
     {
-        $range = $this->credis->zrange($key, $start, $stop, $withscores ? ['withscores' => 1] : null);
+        $key = $this->config->prefix . $key;
+
+        /** @var array|false $range */
+        $range = $this->credis->zRange($key, $start, $stop, $withscores ? ['withscores' => 1] : null);
         if ($range === false) return null;
         return $range;
     }
 
 
     /** @inheritdoc */
-    public function zRem(string $key, $member): int
+    public function zRem(string $key, ...$members): int
     {
-        return $this->credis->zrem($key, $member);
+        $key = $this->config->prefix . $key;
+
+        $args = self::flattenArrays($members);
+        array_unshift($args, $key);
+
+        $value = $this->credis->__call('zrem', $args);
+        return (int) $value;
     }
 
 }

--- a/src/CredisAdapter.php
+++ b/src/CredisAdapter.php
@@ -519,14 +519,19 @@ class CredisAdapter extends Rdb
 
 
     /** @inheritdoc */
-    public function zAdd(string $key, ...$members): int
+    public function zAdd(string $key, array $members): int
     {
         $key = $this->config->prefix . $key;
 
-        $args = $members;
-        array_unshift($args, $key);
+        $args = [];
+        $args[] = $key;
 
-        $res = $this->credis->__call('zadd', $members);
+        foreach ($members as $member => $score) {
+            $args[] = $score;
+            $args[] = $member;
+        }
+
+        $res = $this->credis->__call('zadd', $args);
         return (int) $res;
     }
 

--- a/src/CredisAdapter.php
+++ b/src/CredisAdapter.php
@@ -608,4 +608,45 @@ class CredisAdapter extends Rdb
         return (int) $value;
     }
 
+
+    /** @inheritdoc */
+    public function zCard(string $key): ?int
+    {
+        $key = $this->config->prefix . $key;
+        return $this->credis->zCard($key);
+    }
+
+
+    /** @inheritdoc */
+    public function zCount(string $key, float $min, float $max): ?int
+    {
+        $key = $this->config->prefix . $key;
+        return $this->credis->zCount($key, $min, $max);
+    }
+
+
+    /** @inheritdoc */
+    public function zScore(string $key, string $member): ?float
+    {
+        $key = $this->config->prefix . $key;
+        $score = $this->credis->__call('zscore', [$key, $member]);
+        if (!is_numeric($score)) return null;
+        return (float) $score;
+    }
+
+
+    /** @inheritdoc */
+    public function zRank(string $key, string $member): ?int
+    {
+        $key = $this->config->prefix . $key;
+        return $this->credis->zRank($key, $member);
+    }
+
+
+    /** @inheritdoc */
+    public function zRevRank(string $key, string $member): ?int
+    {
+        $key = $this->config->prefix . $key;
+        return $this->credis->zRevRank($key, $member);
+    }
 }

--- a/src/CredisAdapter.php
+++ b/src/CredisAdapter.php
@@ -545,7 +545,7 @@ class CredisAdapter extends Rdb
 
 
     /** @inheritdoc */
-    public function zRange(string $key, int $start, int $stop, bool $withscores = false): ?array
+    public function zRange(string $key, int $start = 0, int $stop = -1, bool $withscores = false): ?array
     {
         $key = $this->config->prefix . $key;
 

--- a/src/CredisAdapter.php
+++ b/src/CredisAdapter.php
@@ -549,8 +549,14 @@ class CredisAdapter extends Rdb
     {
         $key = $this->config->prefix . $key;
 
+        $args = [];
+
+        if ($withscores) {
+            $args['withscores'] = true;
+        }
+
         /** @var array|false $range */
-        $range = $this->credis->zRange($key, $start, $stop, $withscores ? ['withscores' => 1] : null);
+        $range = $this->credis->zRange($key, $start, $stop, $args);
         if ($range === false) return null;
         return $range;
     }

--- a/src/PhpRedisAdapter.php
+++ b/src/PhpRedisAdapter.php
@@ -603,6 +603,7 @@ class PhpRedisAdapter extends Rdb
     public function zCount(string $key, float $min, float $max): ?int
     {
         /** @var int|false $res */
+        // @phpstan-ignore-next-line
         $res = $this->redis->zCount($key, $min, $max);
         if ($res === false) return null;
         return $res;
@@ -621,6 +622,7 @@ class PhpRedisAdapter extends Rdb
     /** @inheritdoc */
     public function zRank(string $key, string $member): ?int
     {
+        /** @var int|false $res */
         $res = $this->redis->zRank($key, $member);
         if ($res === false) return null;
         return $res;
@@ -630,6 +632,7 @@ class PhpRedisAdapter extends Rdb
     /** @inheritdoc */
     public function zRevRank(string $key, string $member): ?int
     {
+        /** @var int|false $ok */
         $ok = $this->redis->zRevRank($key, $member);
         if ($ok === false) return null;
         return $ok;

--- a/src/PhpRedisAdapter.php
+++ b/src/PhpRedisAdapter.php
@@ -514,20 +514,21 @@ class PhpRedisAdapter extends Rdb
     /** @inheritdoc */
     public function zAdd(string $key, ...$members): int
     {
-        return $this->redis->zadd($key, ...$members);
+        return $this->redis->zAdd($key, ...$members);
     }
 
 
     /** @inheritdoc */
-    public function zIncrby(string $key, ...$members): int
+    public function zIncrBy(string $key, float $value, string $member): float
     {
-        return $this->redis->zincrby($key, ...$members);
+        return $this->redis->zIncrBy($key, $value, $member);
     }
 
 
     /** @inheritdoc */
     public function zRange(string $key, int $start, int $stop, bool $withscores = false): ?array
     {
+        /** @var array|false $range */
         $range = $this->redis->zrange($key, $start, $stop, $withscores);
         if ($range === false) return null;
         return $range;
@@ -535,9 +536,9 @@ class PhpRedisAdapter extends Rdb
 
 
     /** @inheritdoc */
-    public function zRem(string $key, $member): int
+    public function zRem(string $key, ...$members): int
     {
-        return $this->redis->zrem($key, $member);
+        return $this->redis->zRem($key, ...$members);
     }
 
 }

--- a/src/PhpRedisAdapter.php
+++ b/src/PhpRedisAdapter.php
@@ -534,7 +534,7 @@ class PhpRedisAdapter extends Rdb
 
 
     /** @inheritdoc */
-    public function zRange(string $key, int $start, int $stop, bool $withscores = false): ?array
+    public function zRange(string $key, int $start = 0, int $stop = -1, bool $withscores = false): ?array
     {
         /** @var array|false $range */
         $range = $this->redis->zrange($key, $start, $stop, $withscores);

--- a/src/PhpRedisAdapter.php
+++ b/src/PhpRedisAdapter.php
@@ -178,7 +178,7 @@ class PhpRedisAdapter extends Rdb
     /** @inheritdoc */
     public function set(string $key, string $value, int $ttl = 0, array $flags = [])
     {
-        $flags = self::parseFlags($flags);
+        $flags = self::parseSetFlags($flags);
 
         $options = [];
 

--- a/src/PhpRedisAdapter.php
+++ b/src/PhpRedisAdapter.php
@@ -547,7 +547,7 @@ class PhpRedisAdapter extends Rdb
 
         if ($flags['rev']) {
             if ($flags['byscore']) {
-                $this->redis->zRevRangeByScore($key, $start, $stop, [
+                $range = $this->redis->zRevRangeByScore($key, $start, $stop, [
                     'withscores' => $flags['withscores'],
                     'limit' => $limit,
                 ]);
@@ -562,7 +562,7 @@ class PhpRedisAdapter extends Rdb
         }
         else {
             if ($flags['byscore']) {
-                $this->redis->zRangeByScore($key, $start, $stop, [
+                $range = $this->redis->zRangeByScore($key, $start, $stop, [
                     'withscores' => $flags['withscores'],
                     'limit' => $limit,
                 ]);
@@ -576,8 +576,6 @@ class PhpRedisAdapter extends Rdb
             }
         }
 
-        /** @var array|false $range */
-        $range = $this->redis->zrange($key, $start, $stop, $flags);
         if ($range === false) return null;
         return $range;
     }

--- a/src/PhpRedisAdapter.php
+++ b/src/PhpRedisAdapter.php
@@ -590,4 +590,51 @@ class PhpRedisAdapter extends Rdb
         return $this->redis->zRem($key, ...$members);
     }
 
+
+    /** @inheritdoc */
+    public function zCard(string $key): ?int
+    {
+        /** @var int|false $res */
+        $res = $this->redis->zCard($key);
+        if ($res === false) return null;
+        return $res;
+    }
+
+
+    /** @inheritdoc */
+    public function zCount(string $key, float $min, float $max): ?int
+    {
+        /** @var int|false $res */
+        $res = $this->redis->zCount($key, $min, $max);
+        if ($res === false) return null;
+        return $res;
+    }
+
+
+    /** @inheritdoc */
+    public function zScore(string $key, string $member): ?float
+    {
+        $res = $this->redis->zScore($key, $member);
+        if ($res === false) return null;
+        return $res;
+    }
+
+
+    /** @inheritdoc */
+    public function zRank(string $key, string $member): ?int
+    {
+        $res = $this->redis->zRank($key, $member);
+        if ($res === false) return null;
+        return $res;
+    }
+
+
+    /** @inheritdoc */
+    public function zRevRank(string $key, string $member): ?int
+    {
+        $ok = $this->redis->zRevRank($key, $member);
+        if ($ok === false) return null;
+        return $ok;
+    }
+
 }

--- a/src/PhpRedisAdapter.php
+++ b/src/PhpRedisAdapter.php
@@ -546,6 +546,7 @@ class PhpRedisAdapter extends Rdb
     /** @inheritdoc */
     public function zRem(string $key, ...$members): int
     {
+        $members = self::flattenArrays($members);
         return $this->redis->zRem($key, ...$members);
     }
 

--- a/src/PhpRedisAdapter.php
+++ b/src/PhpRedisAdapter.php
@@ -512,9 +512,17 @@ class PhpRedisAdapter extends Rdb
 
 
     /** @inheritdoc */
-    public function zAdd(string $key, ...$members): int
+    public function zAdd(string $key, array $members): int
     {
-        return $this->redis->zAdd($key, ...$members);
+        $args = [];
+        $args[] = $key;
+
+        foreach ($members as $member => $score) {
+            $args[] = $score;
+            $args[] = $member;
+        }
+
+        return (int) @call_user_func_array([$this->redis, 'zAdd'], $args);
     }
 
 

--- a/src/PredisAdapter.php
+++ b/src/PredisAdapter.php
@@ -121,7 +121,7 @@ class PredisAdapter extends Rdb
     /** @inheritdoc */
     public function set(string $key, string $value, int $ttl = 0, array $flags = [])
     {
-        $flags = self::parseFlags($flags);
+        $flags = self::parseSetFlags($flags);
 
         $args = [];
         $args[] = $key;

--- a/src/PredisAdapter.php
+++ b/src/PredisAdapter.php
@@ -423,13 +423,25 @@ class PredisAdapter extends Rdb
 
 
     /** @inheritdoc */
-    public function zRange(string $key, int $start = 0, int $stop = -1, bool $withscores = false): ?array
+    public function zRange(string $key, int $start = 0, int $stop = -1, array $flags = []): ?array
     {
-        $options = [
-            'WITHSCORES' => $withscores,
+        $flags = self::parseRangeFlags($flags);
+
+        $cmd = $flags['rev'] ? 'zRevRange' : 'zRange';
+
+        if ($flags['bylex']) {
+            $cmd .= 'ByLex';
+        }
+        else if ($flags['byscore']) {
+            $cmd .= 'ByScore';
+        }
+
+        $args = [
+            'WITHSCORES' => $flags['withscores'],
+            'LIMIT' => $flags['limit'],
         ];
 
-        $range = $this->predis->zrange($key, $start, $stop, $options);
+        $range = $this->predis->$cmd($key, $start, $stop, $args);
         return $range;
     }
 

--- a/src/PredisAdapter.php
+++ b/src/PredisAdapter.php
@@ -455,4 +455,40 @@ class PredisAdapter extends Rdb
         return (int) @call_user_func_array([$this->predis, 'zrem'], $args);
     }
 
+
+    /** @inheritdoc */
+    public function zCard(string $key): ?int
+    {
+        return $this->predis->zcard($key);
+    }
+
+
+    /** @inheritdoc */
+    public function zCount(string $key, float $min, float $max): ?int
+    {
+        return $this->predis->zcount($key, $min, $max);
+    }
+
+
+    /** @inheritdoc */
+    public function zScore(string $key, string $member): ?float
+    {
+        $score = $this->predis->zscore($key, $member);
+        if ($score === null) return null;
+        return (float) $score;
+    }
+
+
+    /** @inheritdoc */
+    public function zRank(string $key, string $member): ?int
+    {
+        return $this->predis->zrank($key, $member);
+    }
+
+
+    /** @inheritdoc */
+    public function zRevRank(string $key, string $member): ?int
+    {
+        return $this->predis->zrevrank($key, $member);
+    }
 }

--- a/src/PredisAdapter.php
+++ b/src/PredisAdapter.php
@@ -409,7 +409,7 @@ class PredisAdapter extends Rdb
 
 
     /** @inheritdoc */
-    public function zAdd(string $key, ...$members): int
+    public function zAdd(string $key, array $members): int
     {
         return $this->predis->zadd($key, $members);
     }

--- a/src/PredisAdapter.php
+++ b/src/PredisAdapter.php
@@ -423,7 +423,7 @@ class PredisAdapter extends Rdb
 
 
     /** @inheritdoc */
-    public function zRange(string $key, int $start, int $stop, bool $withscores = false): ?array
+    public function zRange(string $key, int $start = 0, int $stop = -1, bool $withscores = false): ?array
     {
         $options = [
             'WITHSCORES' => $withscores,

--- a/src/PredisAdapter.php
+++ b/src/PredisAdapter.php
@@ -423,7 +423,7 @@ class PredisAdapter extends Rdb
 
 
     /** @inheritdoc */
-    public function zRange(string $key, int $start = 0, int $stop = -1, array $flags = []): ?array
+    public function zRange(string $key, $start = null, $stop = null, array $flags = []): ?array
     {
         $flags = self::parseRangeFlags($flags);
 
@@ -431,9 +431,26 @@ class PredisAdapter extends Rdb
 
         if ($flags['bylex']) {
             $cmd .= 'ByLex';
+
+            if ($start and !preg_match('/^\[|^\(/', $start)) {
+                $start = '[' . $start;
+            }
+            if ($stop and !preg_match('/^\[|^\(/', $stop)) {
+                $stop = '[' . $stop;
+            }
+
+            $start = $start ?? '-';
+            $stop = $stop ?? '+';
         }
         else if ($flags['byscore']) {
             $cmd .= 'ByScore';
+
+            $start = $start ?? '-inf';
+            $stop = $stop ?? '+inf';
+        }
+        else {
+            $start = $start ?? 0;
+            $stop = $stop ?? -1;
         }
 
         $args = [

--- a/src/PredisAdapter.php
+++ b/src/PredisAdapter.php
@@ -466,7 +466,9 @@ class PredisAdapter extends Rdb
     /** @inheritdoc */
     public function zCount(string $key, float $min, float $max): ?int
     {
-        return $this->predis->zcount($key, $min, $max);
+        $count = $this->predis->zcount($key, $min, $max);
+        if (!is_numeric($count)) return null;
+        return (int) $count;
     }
 
 

--- a/src/PredisAdapter.php
+++ b/src/PredisAdapter.php
@@ -411,30 +411,36 @@ class PredisAdapter extends Rdb
     /** @inheritdoc */
     public function zAdd(string $key, ...$members): int
     {
-        return $this->predis->zadd($key, ...$members);
+        return $this->predis->zadd($key, $members);
     }
 
 
     /** @inheritdoc */
-    public function zIncrby(string $key, ...$members): int
+    public function zIncrBy(string $key, float $value, string $member): float
     {
-        return $this->predis->zincrby($key, ...$members);
+        return (float) $this->predis->zincrby($key, $value, $member);
     }
 
 
     /** @inheritdoc */
     public function zRange(string $key, int $start, int $stop, bool $withscores = false): ?array
     {
-        $range = $this->predis->zrange($key, $start, $stop, $withscores ? 'WITHSCORES' : null);
-        if ($range === false) return null;
+        $options = [
+            'WITHSCORES' => $withscores,
+        ];
+
+        $range = $this->predis->zrange($key, $start, $stop, $options);
         return $range;
     }
 
 
     /** @inheritdoc */
-    public function zRem(string $key, $member): int
+    public function zRem(string $key, ...$members): int
     {
-        return $this->predis->zrem($key, $member);
+        $args = self::flattenArrays($members);
+        array_unshift($args, $key);
+
+        return (int) @call_user_func_array([$this->predis, 'zrem'], $args);
     }
 
 }

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -752,8 +752,14 @@ abstract class Rdb
      * returns null only if the key is not a sorted set.
      *
      * @param string $key
-     * @param int $start
-     * @param int $stop negative numbers are circular
+     * @param int|string|null $start defaults:
+     *   - natural: `0`
+     *   - byscore: `-inf`
+     *   - bylex: `-` (inf)
+     * @param int|string|null $stop defaults:
+     *   - natural: `-1` (circular, meaning end-of-set)
+     *   - byscore: `+inf`
+     *   - bylex: `+` (inf)
      * @param array $flags
      *  - withscores: include the score with each member (not available for bylex)
      *  - rev: reverse the order
@@ -766,7 +772,7 @@ abstract class Rdb
      *  - a keyed array like `[ member => score ]` (withscores)
      *  - `null` if the key is not a sorted set
      */
-    public abstract function zRange(string $key, int $start = 0, int $stop = -1, array $flags = []): ?array;
+    public abstract function zRange(string $key, $start = null, $stop = null, array $flags = []): ?array;
 
 
     /**

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -649,7 +649,7 @@ abstract class Rdb
      * @param bool $withscores
      * @return null|array
      */
-    public abstract function zRange(string $key, int $start, int $stop, bool $withscores = false): ?array;
+    public abstract function zRange(string $key, int $start = 0, int $stop = -1, bool $withscores = false): ?array;
 
 
     /**

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -620,6 +620,49 @@ abstract class Rdb
 
 
     /**
+     * TODO
+     *
+     * @param string $key
+     * @param array $members
+     * @return int
+     */
+    public abstract function zAdd(string $key, ...$members): int;
+
+
+    /**
+     * TODO
+     *
+     * @param string $key
+     * @param float $value
+     * @param string $member
+     * @return float
+     */
+    public abstract function zIncrBy(string $key, float $value, string $member): float;
+
+
+    /**
+     * TODO
+     *
+     * @param string $key
+     * @param int $start
+     * @param int $stop
+     * @param bool $withscores
+     * @return null|array
+     */
+    public abstract function zRange(string $key, int $start, int $stop, bool $withscores = false): ?array;
+
+
+    /**
+     * TODO
+     *
+     * @param string $key
+     * @param string $members
+     * @return int
+     */
+    public abstract function zRem(string $key, ...$members): int;
+
+
+    /**
      * Do these keys exist?
      *
      * @param string|iterable<string> $keys

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -680,7 +680,7 @@ abstract class Rdb
      * Remove members from a set.
      *
      * @param string $key
-     * @param string $members
+     * @param string[]|string $members
      * @return int number of removed items
      */
     public abstract function zRem(string $key, ...$members): int;

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -748,24 +748,27 @@ abstract class Rdb
      *
      * The default the start/stop range will return all members.
      *
+     * For `bylex` the start/stop is inclusive by default unless overridden
+     * with the `[ or (` syntax.
+     *
      * Note, if the set does not exist it will return an empty array. This
      * returns null only if the key is not a sorted set.
      *
      * @param string $key
      * @param int|string|null $start defaults:
-     *   - natural: `0`
+     *   - rank: `0`
      *   - byscore: `-inf`
      *   - bylex: `-` (inf)
      * @param int|string|null $stop defaults:
-     *   - natural: `-1` (circular, meaning end-of-set)
+     *   - rank: `-1` (circular, meaning end-of-set)
      *   - byscore: `+inf`
      *   - bylex: `+` (inf)
      * @param array $flags
      *  - withscores: include the score with each member (not available for bylex)
      *  - rev: reverse the order
      *  - limit: limit the results (only for byscore + bylex)
-     *  - byscore: sort by score
-     *  - bylex: sort by lexicographical order
+     *  - byscore: filter by score
+     *  - bylex: filter by lexicographical order
      *
      * @return null|array members are either:
      *  - a numeric list, ordered by their score

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -170,7 +170,7 @@ abstract class Rdb
      * @param array $flags
      * @return array
      */
-    protected static function parseFlags(array $flags): array
+    protected static function parseSetFlags(array $flags): array
     {
         // Defaults.
         $output = [

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -253,8 +253,13 @@ abstract class Rdb
             and is_array($flags['limit'])
             and count($flags['limit']) >= 2
         ) {
+            $offset = 0;
+            $count = -1;
+
             // Numeric version.
-            [$offset, $count] = $flags['limit'] ?? [0, -1];
+            if (isset($flags['limit'][0]) and isset($flags['limit'][1])) {
+                [$offset, $count] = $flags['limit'];
+            }
 
             // Keyed version.
             if (isset($flags['limit']['offset'])) {

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -765,13 +765,65 @@ abstract class Rdb
 
 
     /**
-     * Remove members from a set.
+     * Remove members from a sorted set.
      *
      * @param string $key
      * @param string[]|string $members
      * @return int number of removed items
      */
     public abstract function zRem(string $key, ...$members): int;
+
+
+    /**
+     * Get the number of members in a sorted set.
+     *
+     * @param string $key
+     * @return int|null number of items
+     */
+    public abstract function zCard(string $key): ?int;
+
+
+    /**
+     * Get the number of members within a range of scores within a sorted set.
+     *
+     * This has the same semantics as zRange 'by score'.
+     *
+     * @param string $key
+     * @param float $min
+     * @param float $max
+     * @return int|null number of items
+     */
+    public abstract function zCount(string $key, float $min, float $max): ?int;
+
+
+    /**
+     * Get the score of a member in a sorted set.
+     *
+     * @param string $key
+     * @param string $member
+     * @return float|null score
+     */
+    public abstract function zScore(string $key, string $member): ?float;
+
+
+    /**
+     * Get the rank of a member in a sorted set.
+     *
+     * @param string $key
+     * @param string $member
+     * @return int|null rank, 0-indexed
+     */
+    public abstract function zRank(string $key, string $member): ?int;
+
+
+    /**
+     * Get the reversed rank of a member in a sorted set.
+     *
+     * @param string $key
+     * @param string $member
+     * @return int|null rank, 0-indexed
+     */
+    public abstract function zRevRank(string $key, string $member): ?int;
 
 
     /**

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -623,10 +623,10 @@ abstract class Rdb
      * TODO
      *
      * @param string $key
-     * @param array $members
+     * @param float[] $members [ member => score ]
      * @return int
      */
-    public abstract function zAdd(string $key, ...$members): int;
+    public abstract function zAdd(string $key, array $members): int;
 
 
     /**

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -620,44 +620,68 @@ abstract class Rdb
 
 
     /**
-     * TODO
+     * Add items to a sorted set.
+     *
+     * One must indicate a score for each member, the format looks like:
+     *
+     * ```
+     * [
+     *   'a' => 5,
+     *   'b' => 1,
+     *   'c' => 10,
+     * ]
+     * ```
+     *
+     * If the set exists, the member values are updated - these updated members
+     * are excluded from the return count. Otherwise this will create a new
+     * sorted set.
      *
      * @param string $key
      * @param float[] $members [ member => score ]
-     * @return int
+     * @return int number of elements added
      */
     public abstract function zAdd(string $key, array $members): int;
 
 
     /**
-     * TODO
+     * Increment a member's score in a sorted set.
+     *
+     * This will create a new sorted set if it doesn't exist.
      *
      * @param string $key
-     * @param float $value
+     * @param float $value an amount to update by, can be negative
      * @param string $member
-     * @return float
+     * @return float the value after updated
      */
     public abstract function zIncrBy(string $key, float $value, string $member): float;
 
 
     /**
-     * TODO
+     * Get members from a sorted set.
+     *
+     * The default the start/stop range will return all members.
+     *
+     * Note, if the set does not exist it will return an empty array. This
+     * returns null only if the key is not a sorted set.
      *
      * @param string $key
      * @param int $start
-     * @param int $stop
-     * @param bool $withscores
-     * @return null|array
+     * @param int $stop negative numbers are circular
+     * @param bool $withscores return a keyed array [ member => score ]
+     * @return null|array members are either:
+     *  - a numeric list, ordered by their score
+     *  - a keyed array like `[ member => score ]`
+     *  - `null` if the key is not a sorted set
      */
     public abstract function zRange(string $key, int $start = 0, int $stop = -1, bool $withscores = false): ?array;
 
 
     /**
-     * TODO
+     * Remove members from a set.
      *
      * @param string $key
      * @param string $members
-     * @return int
+     * @return int number of removed items
      */
     public abstract function zRem(string $key, ...$members): int;
 

--- a/tests/AdapterTestCase.php
+++ b/tests/AdapterTestCase.php
@@ -461,6 +461,53 @@ abstract class AdapterTestCase extends TestCase
         ];
         $actual = $this->rdb->zRange('zrange:123', 0, 1, ['withscores' => true]);
         $this->assertEquals($expected, $actual);
+
+        // Testing: zCard, zCount, zScore, zRank, zRevRank.
+        $this->rdb->zAdd('ztest', [
+            'a' => 1,
+            'c' => 10,
+            'b' => 5,
+        ]);
+
+        $expected = 3;
+        $actual = $this->rdb->zCard('ztest');
+        $this->assertEquals($expected, $actual);
+
+        $expected = 3;
+        $actual = $this->rdb->zCount('ztest', 0, INF);
+        $this->assertEquals($expected, $actual);
+
+        $expected = 2;
+        $actual = $this->rdb->zCount('ztest', 5, INF);
+        $this->assertEquals($expected, $actual);
+
+        $expected = 1;
+        $actual = $this->rdb->zCount('ztest', 6, INF);
+        $this->assertEquals($expected, $actual);
+
+        $expected = 1;
+        $actual = $this->rdb->zCount('ztest', 3, 7);
+        $this->assertEquals($expected, $actual);
+
+        $expected = 10;
+        $actual = $this->rdb->zScore('ztest', 'c');
+        $this->assertEquals($expected, $actual);
+
+        $expected = 2;
+        $actual = $this->rdb->zRank('ztest', 'c');
+        $this->assertEquals($expected, $actual);
+
+        $expected = 1;
+        $actual = $this->rdb->zRank('ztest', 'b');
+        $this->assertEquals($expected, $actual);
+
+        $expected = 0;
+        $actual = $this->rdb->zRevRank('ztest', 'c');
+        $this->assertEquals($expected, $actual);
+
+        $expected = 1;
+        $actual = $this->rdb->zRevRank('ztest', 'b');
+        $this->assertEquals($expected, $actual);
     }
 }
 

--- a/tests/AdapterTestCase.php
+++ b/tests/AdapterTestCase.php
@@ -411,6 +411,39 @@ abstract class AdapterTestCase extends TestCase
         // zRem.
         $actual = $this->rdb->zRem('zrange:123', 'a');
         $this->assertEquals(1, $actual);
+
+
+        // zAdd, multiple.
+        $expected = 3;
+        $actual = $this->rdb->zAdd('zrange:123', [
+            'a' => 10,
+            'b' => 3,
+            'c' => 5,
+        ]);
+        $this->assertEquals($expected, $actual);
+
+        // zRange, no scores - but results are ordered.
+        $expected = ['b', 'c', 'a'];
+        $actual = $this->rdb->zRange('zrange:123');
+        $this->assertEquals($expected, $actual);
+
+        // zRange, no scores, just the first.
+        $expected = ['b'];
+        $actual = $this->rdb->zRange('zrange:123', 0, 0, false);
+        $this->assertEquals($expected, $actual);
+
+        // zRange, with scores, just the first.
+        $expected = [ 'b' => 3 ];
+        $actual = $this->rdb->zRange('zrange:123', 0, 0, true);
+        $this->assertEquals($expected, $actual);
+
+        // zRange, with scores, truncated.
+        $expected = [
+            'b' => 3,
+            'c' => 5,
+        ];
+        $actual = $this->rdb->zRange('zrange:123', 0, 1, true);
+        $this->assertEquals($expected, $actual);
     }
 }
 

--- a/tests/AdapterTestCase.php
+++ b/tests/AdapterTestCase.php
@@ -405,7 +405,7 @@ abstract class AdapterTestCase extends TestCase
         $this->assertEquals(4, $actual);
 
         // zRange.
-        $actual = $this->rdb->zRange('zrange:123', 0, -1, true);
+        $actual = $this->rdb->zRange('zrange:123', 0, -1, ['withscores' => true]);
         $this->assertEquals(['a' => 4], $actual);
 
         // zRem.
@@ -446,12 +446,12 @@ abstract class AdapterTestCase extends TestCase
 
         // zRange, no scores, just the first.
         $expected = ['b'];
-        $actual = $this->rdb->zRange('zrange:123', 0, 0, false);
+        $actual = $this->rdb->zRange('zrange:123', 0, 0);
         $this->assertEquals($expected, $actual);
 
         // zRange, with scores, just the first.
         $expected = [ 'b' => 3 ];
-        $actual = $this->rdb->zRange('zrange:123', 0, 0, true);
+        $actual = $this->rdb->zRange('zrange:123', 0, 0, ['withscores' => true]);
         $this->assertEquals($expected, $actual);
 
         // zRange, with scores, truncated.
@@ -459,7 +459,7 @@ abstract class AdapterTestCase extends TestCase
             'b' => 3,
             'c' => 5,
         ];
-        $actual = $this->rdb->zRange('zrange:123', 0, 1, true);
+        $actual = $this->rdb->zRange('zrange:123', 0, 1, ['withscores' => true]);
         $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/AdapterTestCase.php
+++ b/tests/AdapterTestCase.php
@@ -431,16 +431,19 @@ abstract class AdapterTestCase extends TestCase
         $this->assertEquals(['a'], $actual);
 
         // zAdd, multiple.
-        $expected = 3;
+        $expected = 6;
         $actual = $this->rdb->zAdd('zrange:123', [
             'a' => 10,
             'b' => 3,
             'c' => 5,
+            'e' => 5,
+            'd' => 5,
+            'f' => 5,
         ]);
         $this->assertEquals($expected, $actual);
 
         // zRange, no scores - but results are ordered.
-        $expected = ['b', 'c', 'a'];
+        $expected = ['b', 'c', 'd', 'e', 'f', 'a'];
         $actual = $this->rdb->zRange('zrange:123');
         $this->assertEquals($expected, $actual);
 
@@ -460,6 +463,36 @@ abstract class AdapterTestCase extends TestCase
             'c' => 5,
         ];
         $actual = $this->rdb->zRange('zrange:123', 0, 1, ['withscores' => true]);
+        $this->assertEquals($expected, $actual);
+
+        // zRange, by lex (with defaults).
+        $expected = [ 'b', 'c', 'd', 'e', 'f', 'a' ];
+        $actual = $this->rdb->zRange('zrange:123', null, null, ['bylex']);
+        $this->assertEquals($expected, $actual);
+
+        // zRange, by lex with inclusive defaults.
+        $expected = [ 'b', 'c', 'd' ];
+        $actual = $this->rdb->zRange('zrange:123', 'a', 'd', ['bylex']);
+        $this->assertEquals($expected, $actual);
+
+        // zRange, by lex with exclusive options.
+        $expected = [ 'b', 'c' ];
+        $actual = $this->rdb->zRange('zrange:123', '-', '(d', ['bylex']);
+        $this->assertEquals($expected, $actual);
+
+        // zRange, by score (defaults).
+        $expected = [ 'b', 'c', 'd', 'e', 'f', 'a' ];
+        $actual = $this->rdb->zRange('zrange:123', null, null, ['byscore']);
+        $this->assertEquals($expected, $actual);
+
+        // zRange, with filters.
+        $expected = [];
+        $actual = $this->rdb->zRange('zrange:123', 0, 1, ['byscore']);
+        $this->assertEquals($expected, $actual);
+
+        // zRange, with proper filters.
+        $expected = ['b', 'c', 'd', 'e', 'f'];
+        $actual = $this->rdb->zRange('zrange:123', 3, 5, ['byscore']);
         $this->assertEquals($expected, $actual);
 
         // Testing: zCard, zCount, zScore, zRank, zRevRank.

--- a/tests/AdapterTestCase.php
+++ b/tests/AdapterTestCase.php
@@ -401,7 +401,7 @@ abstract class AdapterTestCase extends TestCase
         $this->assertEquals(1, $actual);
 
         // zIncrby.
-        $actual = $this->rdb->zIncrby('zrange:123', 3, 'a');
+        $actual = $this->rdb->zIncrBy('zrange:123', 3, 'a');
         $this->assertEquals(4, $actual);
 
         // zRange.
@@ -412,6 +412,23 @@ abstract class AdapterTestCase extends TestCase
         $actual = $this->rdb->zRem('zrange:123', 'a');
         $this->assertEquals(1, $actual);
 
+        // Null sets.
+        $this->rdb->set('zrange:hello', 'not-a-sorted-set');
+        $actual = $this->rdb->zRange('zrange:hello');
+        $this->assertNull($actual);
+
+        // missing set.
+        $this->rdb->del('zrange:hello');
+        $actual = $this->rdb->zRange('zrange:hello');
+        $this->assertEquals([], $actual);
+
+        // zIncrBy creates a set.
+        $this->rdb->del('zrange:hello');
+        $actual = $this->rdb->zIncrBy('zrange:hello', 10, 'a');
+        $this->assertEquals(10, $actual);
+
+        $actual = $this->rdb->zRange('zrange:hello');
+        $this->assertEquals(['a'], $actual);
 
         // zAdd, multiple.
         $expected = 3;

--- a/tests/AdapterTestCase.php
+++ b/tests/AdapterTestCase.php
@@ -397,7 +397,7 @@ abstract class AdapterTestCase extends TestCase
     {
 
         // zAdd.
-        $actual = $this->rdb->zAdd('zrange:123', 1, 'a');
+        $actual = $this->rdb->zAdd('zrange:123', ['a' => 1]);
         $this->assertEquals(1, $actual);
 
         // zIncrby.


### PR DESCRIPTION
This is mostly so phpstan stops screaming so much. But granted, the abstract signatures were missing entirely from the base Rdb class.

Some minor signature changes here also, really just the `zAdd()` method that now behaves much more like predis.

This is in draft - still need to fill the docs.

Perhaps some discussion about what options we can support for zAdd and zRange. For example, maybe an options array instead of a `$withscores` bool is smarter, despite it being the only supported flag in redis 3.0. We could support both I suppose. Overall I don't really want to go beyond what redis 3 supports, but perhaps in future when it's ubiquitous it'd be nice that our signatures don't dramatically change.

I'd also like to get these methods implemented before pushing a release.
- zCount
- zRank
- zCard
- zScore
