### PR TITLE
Fix/object drivers

### DIFF
--- a/src/Objects/HashObjectDriver.php
+++ b/src/Objects/HashObjectDriver.php
@@ -60,13 +60,15 @@ class HashObjectDriver implements RdbObjectDriver
             throw new InvalidArgumentException('Object must implement JsonSerializable');
         }
 
-        $value = $value->jsonSerialize();
+        $blob = $value->jsonSerialize();
 
-        if (!is_array($value)) {
+        if (!is_array($blob)) {
             throw new InvalidArgumentException('Object must serialize to an array');
         }
 
-        $count = $this->rdb->setHash($key, $value);
+        $blob['__class__'] = get_class($value);
+
+        $count = $this->rdb->setHash($key, $blob);
 
         if ($count and $ttl > 0) {
             $this->rdb->expire($key, $ttl);
@@ -94,6 +96,11 @@ class HashObjectDriver implements RdbObjectDriver
             return null;
         }
 
+        if (isset($value['__class__']) and $value['__class__'] !== $expected) {
+            return null;
+        }
+
+        unset($value['__class__']);
         return $expected::fromJson($value);
     }
 
@@ -109,14 +116,16 @@ class HashObjectDriver implements RdbObjectDriver
                 continue;
             }
 
-            $item = $item->jsonSerialize();
+            $blob = $item->jsonSerialize();
 
-            if (!is_array($item)) {
+            if (!is_array($blob)) {
                 throw new InvalidArgumentException('Object must serialize to an array');
             }
 
-            $sizes[$key] = $this->rdb->setHash($key, $item);
+            $blob['__class__'] = get_class($item);
+            $sizes[$key] = $this->rdb->setHash($key, $blob);
         }
+        unset($item);
 
         return $sizes;
     }
@@ -144,6 +153,11 @@ class HashObjectDriver implements RdbObjectDriver
                 continue;
             }
 
+            if (isset($item['__class__']) and $item['__class__'] !== $expected) {
+                continue;
+            }
+
+            unset($item['__class__']);
             $output[$key] = $expected::fromJson($item);
         }
 

--- a/src/Objects/JsonObjectDriver.php
+++ b/src/Objects/JsonObjectDriver.php
@@ -41,13 +41,14 @@ class JsonObjectDriver implements RdbObjectDriver
             throw new InvalidArgumentException('Object must implement JsonSerializable');
         }
 
-        $value = $value->jsonSerialize();
+        $blob = $value->jsonSerialize();
 
-        if (!is_array($value)) {
+        if (!is_array($blob)) {
             throw new InvalidArgumentException('Object must serialize to an array');
         }
 
-        return $this->rdb->setJson($key, $value, $ttl);
+        $blob['__class__'] = get_class($value);
+        return $this->rdb->setJson($key, $blob, $ttl);
     }
 
 
@@ -74,6 +75,11 @@ class JsonObjectDriver implements RdbObjectDriver
             return null;
         }
 
+        if (isset($value['__class__']) and $value['__class__'] !== $expected) {
+            return null;
+        }
+
+        unset($value['__class__']);
         return $expected::fromJson($value);
     }
 
@@ -89,20 +95,22 @@ class JsonObjectDriver implements RdbObjectDriver
                 continue;
             }
 
-            $item = $item->jsonSerialize();
+            $blob = $item->jsonSerialize();
 
-            if (!is_array($item)) {
+            if (!is_array($blob)) {
                 throw new InvalidArgumentException('Object must serialize to an array');
             }
 
-            $item = json_encode($item);
-            $error = json_last_error();
+            $blob['__class__'] = get_class($item);
+            $blob = json_encode($blob);
 
+            $error = json_last_error();
             if ($error !== JSON_ERROR_NONE) {
                 throw new JsonException(json_last_error_msg(), $error);
             }
 
-            $sizes[$key] = strlen($item);
+            $sizes[$key] = strlen($blob);
+            $item = $blob;
         }
         unset($item);
 
@@ -144,6 +152,11 @@ class JsonObjectDriver implements RdbObjectDriver
                 continue;
             }
 
+            if (isset($value['__class__']) and $value['__class__'] !== $expected) {
+                continue;
+            }
+
+            unset($value['__class__']);
             $output[$key] = $expected::fromJson($value);
         }
 

--- a/src/Objects/MsgPackObjectDriver.php
+++ b/src/Objects/MsgPackObjectDriver.php
@@ -43,13 +43,14 @@ class MsgPackObjectDriver implements RdbObjectDriver
             throw new InvalidArgumentException('Object must implement JsonSerializable');
         }
 
-        $value = $value->jsonSerialize();
+        $blob = $value->jsonSerialize();
 
-        if (!is_array($value)) {
+        if (!is_array($blob)) {
             throw new InvalidArgumentException('Object must serialize to an array');
         }
 
-        return $this->rdb->pack($key, $value, $ttl);
+        $blob['__class__'] = get_class($value);
+        return $this->rdb->pack($key, $blob, $ttl);
     }
 
 
@@ -76,6 +77,11 @@ class MsgPackObjectDriver implements RdbObjectDriver
             return null;
         }
 
+        if (isset($value['__class__']) and $value['__class__'] !== $expected) {
+            return null;
+        }
+
+        unset($value['__class__']);
         return $expected::fromJson($value);
     }
 
@@ -91,14 +97,17 @@ class MsgPackObjectDriver implements RdbObjectDriver
                 continue;
             }
 
-            $item = $item->jsonSerialize();
+            $blob = $item->jsonSerialize();
 
-            if (!is_array($item)) {
+            if (!is_array($blob)) {
                 throw new InvalidArgumentException('Object must serialize to an array');
             }
 
-            $item = MessagePack::pack($item);
-            $sizes[$key] = strlen($item);
+            $blob['__class__'] = get_class($item);
+            $blob = MessagePack::pack($blob);
+
+            $sizes[$key] = strlen($blob);
+            $item = $blob;
         }
         unset($item);
 
@@ -145,6 +154,11 @@ class MsgPackObjectDriver implements RdbObjectDriver
                 continue;
             }
 
+            if (isset($value['__class__']) and $value['__class__'] !== $expected) {
+                continue;
+            }
+
+            unset($value['__class__']);
             $output[$key] = $expected::fromJson($value);
         }
 

--- a/src/Objects/PhpObjectDriver.php
+++ b/src/Objects/PhpObjectDriver.php
@@ -82,9 +82,11 @@ class PhpObjectDriver implements RdbObjectDriver
         $output = [];
 
         foreach ($items as $key => $item) {
+            if (!$key or !$item) continue;
+
             $item = @unserialize($item) ?: null;
 
-            if (!$key or !$item) continue;
+            if (!$item) continue;
 
             if (!is_object($item)) continue;
 

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -73,13 +73,23 @@ abstract class Rdb
             $this->config = new RdbConfig($config);
         }
 
+        $this->getObjectDriver();
+    }
+
+
+    protected function getObjectDriver(): RdbObjectDriver
+    {
         $class = $this->config->object_driver;
 
-        if (!is_subclass_of($class, RdbObjectDriver::class)) {
-            throw new InvalidArgumentException('Invalid object driver: ' . $class);
+        if ($this->driver === null or get_class($this->driver) !== $class) {
+            if (!is_subclass_of($class, RdbObjectDriver::class)) {
+                throw new InvalidArgumentException('Invalid object driver: ' . $class);
+            }
+
+            $this->driver = new $class($this);
         }
 
-        $this->driver = new $class($this);
+        return $this->driver;
     }
 
 
@@ -1201,7 +1211,7 @@ abstract class Rdb
      */
     public function setObject(string $key, $value, $ttl = 0): int
     {
-        return $this->driver->setObject($key, $value, $ttl);
+        return $this->getObjectDriver()->setObject($key, $value, $ttl);
     }
 
 
@@ -1228,7 +1238,7 @@ abstract class Rdb
             throw new InvalidArgumentException('Not a class or interface: ' . $expected);
         }
 
-        return $this->driver->getObject($key, $expected);
+        return $this->getObjectDriver()->getObject($key, $expected);
     }
 
 
@@ -1261,7 +1271,7 @@ abstract class Rdb
             return [];
         }
 
-        $items = $this->driver->mGetObjects($keys, $expected);
+        $items = $this->getObjectDriver()->mGetObjects($keys, $expected);
 
         if ($nullish) {
             $items = $items + array_fill_keys($keys, null);
@@ -1325,7 +1335,7 @@ abstract class Rdb
             return [];
         }
 
-        return $this->driver->mSetObjects($items);
+        return $this->getObjectDriver()->mSetObjects($items);
     }
 
 

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -1228,8 +1228,12 @@ abstract class Rdb
      *
      * IMPORTANT: the `$expected` parameter will become mandatory in v2.
      *
+     * Behaviour of `$expected` changes between drivers. For PHP (default) this
+     * permits inherited assertions. For everything else (Hash, MsgPack, JSON)
+     * this must be the exact type.
+     *
      * @param string $key
-     * @param string|null $expected Ensure the result inherits/is this type
+     * @param string|null $expected
      * @return object|null
      * @throws InvalidArgumentException
      */
@@ -1254,8 +1258,12 @@ abstract class Rdb
      *
      * IMPORTANT: the `$expected` parameter will become mandatory in v2.
      *
+     * Behaviour of `$expected` changes between drivers. For PHP (default) this
+     * permits inherited assertions. For everything else (Hash, MsgPack, JSON)
+     * this must be the exact type.
+     *
      * @param iterable<string> $keys Non-prefixed keys
-     * @param string|null $expected Ensure all results inherits/is of this type
+     * @param string|null $expected
      * @param bool $nullish (false) return empty values
      * @return (object|null)[] [ key => item ]
      * @throws InvalidArgumentException

--- a/src/Rdb.php
+++ b/src/Rdb.php
@@ -52,8 +52,8 @@ abstract class Rdb
     public $config;
 
 
-    /** @var RdbObjectDriver */
-    public $driver;
+    /** @var RdbObjectDriver|null */
+    protected $driver;
 
 
     /**
@@ -77,6 +77,11 @@ abstract class Rdb
     }
 
 
+    /**
+     * Get the current object driver.
+     *
+     * @return RdbObjectDriver
+     */
     protected function getObjectDriver(): RdbObjectDriver
     {
         $class = $this->config->object_driver;

--- a/tests/AdapterTestTrait.php
+++ b/tests/AdapterTestTrait.php
@@ -3,12 +3,15 @@
 namespace kbtests;
 
 use ArrayIterator;
+use Countable;
 use karmabunny\rdb\Objects\HashObjectDriver;
 use karmabunny\rdb\Objects\JsonObjectDriver;
 use karmabunny\rdb\Objects\MsgPackObjectDriver;
 use karmabunny\rdb\Objects\PhpObjectDriver;
 use karmabunny\rdb\Rdb;
+use karmabunny\rdb\RdbHelperTrait;
 use karmabunny\rdb\RdbJsonObject;
+use MessagePack\MessagePack;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use Traversable;
@@ -476,16 +479,16 @@ trait AdapterTestTrait
     {
         // command - expected
         return [
-            'php' => [ PhpObjectDriver::class ],
-            'json' => [ JsonObjectDriver::class ],
-            'hash' => [ HashObjectDriver::class ],
-            'msgpack' => [ MsgPackObjectDriver::class ],
+            'php' => [ PhpObjectDriver::class, fn($object) => strlen(serialize($object)) ],
+            'json' => [ JsonObjectDriver::class, fn($object) => strlen(json_encode($object->jsonSerialize() + ['__class__' => get_class($object)])) ],
+            'hash' => [ HashObjectDriver::class, fn($object) => count($object) + 1 ],
+            'msgpack' => [ MsgPackObjectDriver::class, fn($object) => strlen(MessagePack::pack($object->jsonSerialize() + ['__class__' => get_class($object)])) ],
         ];
     }
 
 
     /** @dataProvider dataObjectDrivers */
-    public function testObjects($driver)
+    public function testObjects($driver, $lengthFn)
     {
         $this->rdb->config->object_driver = $driver;
 
@@ -493,34 +496,34 @@ trait AdapterTestTrait
         $object = new RandoObject([ 'foo' => 123, 'bar' => 456 ]);
 
         $actual = $this->rdb->setObject('obj:1', $object);
-        $expected = strlen(serialize($object));
+        $expected = $lengthFn($object);
         $this->assertEquals($expected, $actual);
 
         $exists = $this->rdb->exists('obj:1');
         $this->assertEquals(1, $exists);
 
-        $actual = $this->rdb->getObject('obj:1');
-        $this->assertEquals($object, $actual);
+        // Still test deprecated behaviour for now
+        if ($driver === PhpObjectDriver::class) {
+            $actual = $this->rdb->getObject('obj:1');
+            $this->assertEquals($object, $actual);
+        }
 
         $actual = $this->rdb->getObject('obj:1', RandoObject::class);
         $this->assertEquals($object, $actual);
 
-        $actual = $this->rdb->getObject('obj:1', stdClass::class);
+        $actual = $this->rdb->getObject('obj:1', RandoObject2::class);
         $this->assertNull($actual);
 
         // multi get/set objects
         $objects = [
             'multi:1' => new RandoObject([ 'foo' => 123, 'bar' => 456 ]),
             'multi:2' => new RandoObject([ 'foo' => 'aaa', 'bar' => ['bbb', 'ccc'] ]),
-            'multi:3' => (object) ['xyz' => 'abc', 'def' => [1,2,3,4]],
+            'multi:3' => new RandoObject2(),
         ];
 
-        $expected = array_map(function($item) {
-            return strlen(serialize($item));
-        }, $objects);
-
+        $expected = array_map($lengthFn, $objects);
         $actual = $this->rdb->mSetObjects($objects);
-        $this->assertEquals($expected, $actual);
+        $this->assertEquals($expected, $actual, json_encode($actual));
 
         $keys = [
             'multi:1',
@@ -529,14 +532,23 @@ trait AdapterTestTrait
             'multi:3',
         ];
 
-        // Fetch all, the null key is filtered out.
-        $actual = $this->rdb->mGetObjects($keys);
-        $this->assertEquals($objects, $actual);
+        // Fetch all, the null key and non-matching types are filtered out.
+        $actual = $this->rdb->mGetObjects($keys, RandoObject::class);
 
-        $actual = $this->rdb->mScanObjects($keys);
-        $this->assertInstanceOf(Traversable::class, $actual);
-        $actual = iterator_to_array($actual);
-        $this->assertEquals($objects, $actual);
+        $this->assertArrayHasKey('multi:1', $actual);
+        $this->assertEquals($objects['multi:1'], $actual['multi:1']);
+
+        $this->assertArrayHasKey('multi:2', $actual);
+        $this->assertEquals($objects['multi:2'], $actual['multi:2']);
+
+        $this->assertArrayNotHasKey('multi:3', $actual);
+        $this->assertArrayNotHasKey('multi:null', $actual);
+
+        // Just the one outlier.
+        $actual = $this->rdb->mGetObjects($keys, RandoObject2::class);
+        $this->assertCount(1, $actual);
+        $this->assertArrayHasKey('multi:3', $actual);
+        $this->assertEquals($objects['multi:3'], $actual['multi:3']);
 
         // Fetch all, _including_ the null key.
         $expected = [
@@ -546,13 +558,16 @@ trait AdapterTestTrait
             'multi:3' => $objects['multi:3'],
         ];
 
-        $actual = $this->rdb->mGetObjects($keys, null, true);
-        $this->assertEquals($expected, $actual);
+        // Still test deprecated behaviour for now.
+        if ($driver === PhpObjectDriver::class) {
+            $actual = $this->rdb->mGetObjects($keys, null, true);
+            $this->assertEquals($expected, $actual);
 
-        $actual = $this->rdb->mScanObjects($keys, null, true);
-        $this->assertInstanceOf(Traversable::class, $actual);
-        $actual = iterator_to_array($actual);
-        $this->assertEquals($expected, $actual);
+            $actual = $this->rdb->mScanObjects($keys, null, true);
+            $this->assertInstanceOf(Traversable::class, $actual);
+            $actual = iterator_to_array($actual);
+            $this->assertEquals($expected, $actual);
+        }
 
         // Fetch just the 'randoboject' keys.
         $expected = [
@@ -1165,8 +1180,10 @@ trait AdapterTestTrait
 }
 
 
-class RandoObject implements RdbJsonObject
+class RandoObject implements RdbJsonObject, Countable
 {
+    use RdbHelperTrait;
+
     public $foo;
     public $bar;
 
@@ -1194,5 +1211,32 @@ class RandoObject implements RdbJsonObject
     public function jsonSerialize(): array
     {
         return $this->toArray();
+    }
+
+
+    // For hash object driver.
+    public function count(): int
+    {
+        $keys = self::flattenKeys($this->toArray());
+        return count($keys);
+    }
+}
+
+
+class RandoObject2 implements RdbJsonObject, Countable
+{
+    public function jsonSerialize(): array
+    {
+        return [];
+    }
+
+    public static function fromJson(array $json): self
+    {
+        return new self();
+    }
+
+    public function count(): int
+    {
+        return 0;
     }
 }

--- a/tests/CredisStandaloneTest.php
+++ b/tests/CredisStandaloneTest.php
@@ -45,7 +45,7 @@ final class CredisStandaloneTest extends TestCase
 
     public function tearDown(): void
     {
-        $this->rdb->driver = PhpObjectDriver::class;
+        $this->rdb->config->object_driver = PhpObjectDriver::class;
     }
 
 }

--- a/tests/CredisTest.php
+++ b/tests/CredisTest.php
@@ -44,7 +44,7 @@ final class CredisTest extends TestCase
 
     public function tearDown(): void
     {
-        $this->rdb->driver = PhpObjectDriver::class;
+        $this->rdb->config->object_driver = PhpObjectDriver::class;
     }
 
 }

--- a/tests/PhpRedisTest.php
+++ b/tests/PhpRedisTest.php
@@ -44,7 +44,7 @@ final class PhpRedisTest extends TestCase
 
     public function tearDown(): void
     {
-        $this->rdb->driver = PhpObjectDriver::class;
+        $this->rdb->config->object_driver = PhpObjectDriver::class;
     }
 
 }

--- a/tests/PredisTest.php
+++ b/tests/PredisTest.php
@@ -42,7 +42,7 @@ final class PredisTest extends TestCase
 
     public function tearDown(): void
     {
-        $this->rdb->driver = PhpObjectDriver::class;
+        $this->rdb->config->object_driver = PhpObjectDriver::class;
     }
 
 }


### PR DESCRIPTION
Our object driver tests was only testing the default `PhpObjectDriver`. Then we discovered that the expected assertions were not working as intended. Much chaos.

- This fixes up tests to include exceptions for deprecated behaviour while testing the newer drivers.
- Rdb now switches the to the correct driver after modifying the config. 
- Object drivers now assert their expected class.
